### PR TITLE
Implement endpoints for liveness/readiness Probes

### DIFF
--- a/db/queries.go
+++ b/db/queries.go
@@ -69,3 +69,11 @@ func (m VActionResponseModel) GetLastAction() (*VActionResponseModel, error) {
 	}
 	return &m, nil
 }
+
+func (m VActionResponseModel) Ping() error {
+	if err := Sess.Query(stmts.SELECT_CURRENT_TIMEUUID).Exec(); err != nil {
+		libs.Log.Error(err)
+		return err
+	}
+	return nil
+}

--- a/db/stmts/stmts.go
+++ b/db/stmts/stmts.go
@@ -14,4 +14,9 @@ const (
 		SELECT * FROM %s.alog_namespace_type WHERE namespace = ? AND type = ? LIMIT ?;
 
 	`
+
+	SELECT_CURRENT_TIMEUUID = `
+		SELECT now() FROM system.local;
+
+	`
 )

--- a/routes.go
+++ b/routes.go
@@ -42,5 +42,13 @@ func start_http_router() {
 
 	})
 
+	r.Route("/alive", func(r chi.Router) {
+		r.Get("/", views.Alive)
+	})
+
+	r.Route("/ready", func(r chi.Router) {
+		r.Get("/", views.Ready)
+	})
+
 	http.ListenAndServe(":3001", r)
 }

--- a/views/alive.go
+++ b/views/alive.go
@@ -1,0 +1,9 @@
+package views
+
+import (
+	"net/http"
+)
+
+func Alive(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}

--- a/views/ready.go
+++ b/views/ready.go
@@ -1,0 +1,15 @@
+package views
+
+import (
+	"net/http"
+
+	"github.com/k8guard/k8guard-report/db"
+)
+
+func Ready(w http.ResponseWriter, r *http.Request) {
+	v := db.VActionResponseModel{}
+	if err := v.Ping(); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+	w.WriteHeader(http.StatusOK)
+}


### PR DESCRIPTION
As mentioned in the issue #7 , I implemented the `/alive` and `/ready` endpoints.

- For `livenessProbe`, `/alive` always returns `200 OK`
- For `readinessProbe`, `/ready` returns `200 OK` when it can ensure Cassandra connection and `503 ServiceUnavailable` when it cannot.